### PR TITLE
Change format of NDK and CMake install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
   - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > $ANDROID_HOME/licenses/android-sdk-license
   - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> $ANDROID_HOME/licenses/android-sdk-license
 install:
-  - echo y | sdkmanager 'ndk-bundle'
-  - echo y | sdkmanager 'cmake;3.6.4111459'
-  - echo y | sdkmanager 'lldb;3.0'
+  - echo y | sdkmanager "ndk-bundle"
+  - echo y | sdkmanager "cmake;3.6.4111459"
+  - echo y | sdkmanager "lldb;3.0"
 android:
   components:
     - tools


### PR DESCRIPTION
Travis cannot successfully find cmake if wrapped around single quotes or no quotes with newer versions of Android SDK.